### PR TITLE
Switch from tfsec to trivy

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,3 +42,4 @@ jobs:
           scan-type: 'config'
           severity: 'CRITICAL,HIGH'
           exit-code: 1
+          hide-progress: true

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -36,8 +36,9 @@ jobs:
               repo: context.repo.repo,
               body: output
             })
-      - name: Terraform security scan
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.32.0
         with:
-          working_directory: ${{ inputs.working_directory }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          scan-type: 'config'
+          severity: 'CRITICAL,HIGH'
+          exit-code: 1


### PR DESCRIPTION
tfsec has been retired in favour of trivy.

Only reporting CRITICAL and HIGH issues for now.

You can see an example in https://github.com/brightnetwork/terraform-website/actions/runs/16118552581/job/45478511881

Merging this means a small amount of short-term pain, dealing with (or silencing) new errors.